### PR TITLE
Add acl for wazo-push-mobile endpoints

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -69,6 +69,7 @@ wazo-webhookd:
   system_user: wazo-webhookd
   acl:
     - 'auth.users.*.read'
+    - 'auth.users.*.external.mobile.read'
 
 xivo-agentd:
   system_user: xivo-agentd


### PR DESCRIPTION
Push mobile now use the webhookd global auth credentials.
So we must adds required acl for webhookd.