### PR TITLE
Add another acl for wazo-push-mobile endpoints

### DIFF
--- a/etc/wazo-auth-keys/config.yml
+++ b/etc/wazo-auth-keys/config.yml
@@ -70,6 +70,7 @@ wazo-webhookd:
   acl:
     - 'auth.users.*.read'
     - 'auth.users.*.external.mobile.read'
+    - 'auth.mobile.external.config.read'
 
 xivo-agentd:
   system_user: xivo-agentd


### PR DESCRIPTION
push-mobile also need auth.mobile.external.config.read